### PR TITLE
 Add HTTP to HTTPS redirect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 FEDERATED_AWS_RP_STACK_NAME	:= FederatedAWSRP
 FEDERATED_AWS_RP_CODE_STORAGE_S3_PREFIX	:= federated-aws-rp
-PROD_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME	:= public.us-west-2.infosec.mozilla.org
-DEV_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME	:= public.us-west-2.security.allizom.org
+PROD_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME	:= public.us-east-1.infosec.mozilla.org
+DEV_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME	:= public.us-east-1.security.allizom.org
 PROD_ACCOUNT_ID		:= 371522382791
 DEV_ACCOUNT_ID		:= 656532927350
 PROD_RP_DATA_STORE_S3_BUCKET_NAME	:= prod-mozilla-aws-federated-rp-data-store
@@ -10,12 +10,10 @@ PROD_DOMAIN_NAME	:= aws.security.mozilla.org
 DEV_DOMAIN_NAME		:= aws.security.allizom.org
 PROD_DOMAIN_ZONE	:= security.mozilla.org.
 DEV_DOMAIN_ZONE		:= security.allizom.org.
-PROD_CERT_ARN		:= arn:aws:acm:us-west-2:371522382791:certificate/697a9eb0-0145-4d18-ba7b-7d3b19c4eeed
-DEV_CERT_ARN		:= arn:aws:acm:us-west-2:656532927350:certificate/46428d8b-7b26-4ad0-84d1-cd2d386e7a43
+PROD_CERT_ARN		:= arn:aws:acm:us-east-1:371522382791:certificate/055b681f-e48c-4aef-9a12-c4c276b0e73a
+DEV_CERT_ARN		:= arn:aws:acm:us-east-1:656532927350:certificate/8f78c838-67e8-426b-8132-61165bf2cd7b
 PROD_CLIENT_ID		:= N7lULzWtfVUDGymwDs0yDEq6ZcwmFazj
-# DEV_CLIENT_ID		:= xRFzU2bj7Lrbo3875aXwyxIArdkq1AOT
 PROD_DISCOVERY_URL	:= https://auth.mozilla.auth0.com/.well-known/openid-configuration
-# DEV_DISCOVERY_URL	:= https://auth-dev.mozilla.auth0.com/.well-known/openid-configuration
 
 .PHONE: deploy-aws-federated-rp-dev
 deploy-aws-federated-rp-dev:

--- a/federated-aws-rp.yaml
+++ b/federated-aws-rp.yaml
@@ -117,23 +117,14 @@ Resources:
       # preventing this resource from creating
       LogGroupName: !Join [ '/', ['/aws/lambda', !Ref 'AwsFederatedRpFunction' ] ]
       RetentionInDays: 14
-  AwsFederatedRpDomainName:
-    Type: AWS::ApiGateway::DomainName
-    Condition: UseCustomDomainName
-    Properties:
-      RegionalCertificateArn: !Ref CertificateArn
-      DomainName: !Ref CustomDomainName
-      EndpointConfiguration:
-        Types:
-          - REGIONAL
   AwsFederatedRpRoute53RecordSet:
     Type: AWS::Route53::RecordSet
     Condition: UseCustomDomainName
     Properties:
       AliasTarget:
-        DNSName: !GetAtt AwsFederatedRpDomainName.RegionalDomainName
-        HostedZoneId: !GetAtt AwsFederatedRpDomainName.RegionalHostedZoneId
-      Comment: Bind the custom domain name to the AwsFederatedRp API Gateway
+        DNSName: !GetAtt AwsFederatedRpCloudFrontDistribution.DomainName
+        HostedZoneId: Z2FDTNDATAQYW2  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget-1.html
+      Comment: Bind the custom domain name to the AwsFederatedRp CloudFront fronted API Gateway
       HostedZoneName: !Ref DomainNameZone
       Name: !Ref CustomDomainName
       Type: A
@@ -146,13 +137,6 @@ Resources:
       EndpointConfiguration:
         Types:
           - REGIONAL
-  AwsFederatedRpBasePathMapping:
-    Type: AWS::ApiGateway::BasePathMapping
-    Condition: UseCustomDomainName
-    Properties:
-      DomainName: !Ref AwsFederatedRpDomainName
-      RestApiId: !Ref AwsFederatedRpApi
-      Stage: !Ref AwsFederatedRpApiStage
   AwsFederatedRpLambdaPermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -216,9 +200,10 @@ Resources:
         Uri: !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', ':lambda:path/2015-03-31/functions/', !GetAtt 'AwsFederatedRpFunction.Arn', '/invocations' ] ]
       ResourceId: !Ref AwsFederatedRpResource
       RestApiId: !Ref AwsFederatedRpApi
-# https://stackoverflow.com/q/46578615/168874
-# https://stackoverflow.com/q/52909329/168874
   AwsFederatedRpRootRequest:
+    # This resource is necessary to get API Gateway to respond to requests for the '/' path
+    # https://stackoverflow.com/q/46578615/168874
+    # https://stackoverflow.com/q/52909329/168874
     DependsOn: AwsFederatedRpLambdaPermission
     Type: AWS::ApiGateway::Method
     Properties:
@@ -235,6 +220,60 @@ Resources:
       # https://stackoverflow.com/a/56121914/168874
       ResourceId: !GetAtt AwsFederatedRpApi.RootResourceId
       RestApiId: !Ref AwsFederatedRpApi
+  AwsFederatedRpCloudFrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    Condition: UseCustomDomainName
+    Properties:
+      DistributionConfig:
+        Aliases:
+          - !Ref CustomDomainName
+        Comment: !Join [ ':', [!Ref 'AWS::StackName', 'AWS Federated RP CloudFront distribution']]
+        DefaultCacheBehavior:
+          AllowedMethods:
+            - GET
+            - HEAD
+          Compress: true
+          DefaultTTL: 0
+          MinTTL: 0
+          MaxTTL: 0
+          ForwardedValues:
+            Cookies:
+              Forward: all
+            QueryString: true
+            Headers:
+              # Explicity requesting that "Referer" be passed through because we need it and there doesn't seem
+              # to be a way to request that all headers be passed through
+              # https://gist.github.com/gene1wood/c0249066d2562e410ddecd8a6fee8306
+              - Referer
+          TargetOriginId: AwsFederatedRpCloudFrontOriginId
+          ViewerProtocolPolicy: redirect-to-https
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-distributionconfig.html#cfn-cloudfront-distribution-distributionconfig-defaultrootobject
+        DefaultRootObject: ''  # "If you don't want to specify a default root object when you create a distribution, include an empty DefaultRootObject element."
+        Enabled: true
+        HttpVersion: http2
+        IPV6Enabled: true
+        #Logging:
+        #  Logging
+        Origins:
+          - CustomOriginConfig:
+              OriginProtocolPolicy: https-only
+              OriginSSLProtocols:
+                - TLSv1.2
+            DomainName: !Join [ '.', [ !Ref 'AwsFederatedRpApi', 'execute-api', !Ref 'AWS::Region', 'amazonaws.com' ] ]
+            Id: AwsFederatedRpCloudFrontOriginId
+            OriginPath: !Join [ '', [ '/', !Ref 'AwsFederatedRpApiStage' ] ]
+        PriceClass: PriceClass_100  # US, Canada, Europe, Israel
+        ViewerCertificate:
+          AcmCertificateArn: !Ref CertificateArn
+          MinimumProtocolVersion: TLSv1.2_2018
+          SslSupportMethod: sni-only
+      Tags:
+        - Key: application
+          Value: federated-aws-rp
+        - Key: stack
+          Value: !Ref AWS::StackName
+        - Key: source
+          Value: https://github.com/mozilla-iam/federated-aws-rp/
 Outputs:
   AwsFederatedRpUrl:
     Description: The URL of the AWS Federated RP

--- a/federated-aws-rp.yaml
+++ b/federated-aws-rp.yaml
@@ -5,11 +5,6 @@ Metadata:
   'AWS::CloudFormation::Interface':
     ParameterGroups:
     - Label:
-        default: S3
-      Parameters:
-      - S3BucketName
-      - StoreS3FilePath
-    - Label:
         default: OpenID Connect
       Parameters:
       - ClientId
@@ -21,10 +16,6 @@ Metadata:
       - DomainNameZone
       - CertificateArn
     ParameterLabels:
-      S3BucketName:
-        default: S3 Bucket Name
-      StoreS3FilePath:
-        default: Store S3 File Path
       ClientId:
         default: Client ID issued by the identity provider
       DiscoveryUrl:
@@ -36,13 +27,6 @@ Metadata:
       CertificateArn:
         default: AWS ACM Certificate ARN for the Custom DNS Domain Name
 Parameters:
-  S3BucketName:
-    Type: String
-    Description: The S3 bucket containing the group role map file in
-  StoreS3FilePath:
-    Type: String
-    Description: The path to the AWS Federated RP store file
-    Default: aws-federated-rp-store.json
   ClientId:
     Type: String
     Description: OIDC Application/Client Client ID
@@ -94,20 +78,6 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: '*'
-        - PolicyName: AllowModifyS3Store
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - s3:GetObject
-                  - s3:PutObject
-                Resource:
-                  - !Join ['', ['arn:aws:s3:::', !Ref 'S3BucketName', '/', !Ref 'StoreS3FilePath']]
-              - Effect: Allow
-                Action:
-                  - s3:ListBucket
-                Resource: !Join ['', ['arn:aws:s3:::', !Ref 'S3BucketName']]
         - PolicyName: AllowAssumeRoleWithWebIdentity
           PolicyDocument:
             Version: 2012-10-17
@@ -124,8 +94,6 @@ Resources:
       Code: build/
       Environment:
         Variables:
-          S3_BUCKET_NAME: !Ref S3BucketName
-          S3_FILE_PATH_STORE: !Ref StoreS3FilePath
           CLIENT_ID: !Ref ClientId
           DISCOVERY_URL: !Ref DiscoveryUrl
           DOMAIN_NAME: !Ref CustomDomainName  # What if a domain name isn't provided?

--- a/functions/federated_aws_rp/app.py
+++ b/functions/federated_aws_rp/app.py
@@ -136,6 +136,7 @@ def login(state: str, code: str, cookie_header: str) -> dict:
             'statusCode': 200,
             'headers': {
                 'Content-Type': 'text/html',
+                'Cache-Control': 'max-age=0',
                 'Set-Cookie': '{}={}; Secure; HttpOnly; Max-Age=3600; SameSite=strict'.format(
                     CONFIG.cookie_name,
                     encode_cookie_value(store))
@@ -199,6 +200,7 @@ def redirect_to_idp(
         'statusCode': 302,
         'headers': {
             'Location': redirect_url,
+            'Cache-Control': 'max-age=0',
             'Set-Cookie': '{}={}; Secure; HttpOnly; Max-Age=3600'.format(
                 CONFIG.cookie_name,
                 encode_cookie_value(store)),
@@ -219,9 +221,10 @@ def lambda_handler(event: dict, context: dict) -> dict:
     global discovery_document
 
     path = event.get('path')
+    logger.debug('event is {}'.format(event))
     headers = event['headers'] if event['headers'] is not None else {}
-    cookie_header = headers.get('cookie', '')
-    referer = headers.get('referer', '')
+    cookie_header = headers.get('Cookie', '')
+    referer = headers.get('Referer', '')
     query_string_parameters = (
         event['queryStringParameters']
         if event['queryStringParameters'] is not None else {})

--- a/functions/federated_aws_rp/config.py
+++ b/functions/federated_aws_rp/config.py
@@ -6,9 +6,6 @@ from jinja2 import Template
 
 class Config:
     def __init__(self):
-        self.s3_bucket_name = os.getenv('S3_BUCKET_NAME')
-        self.s3_file_path_store = os.getenv(
-            'S3_FILE_PATH_STORE', 'federated-aws-rp-store.json')
         self.client_id = os.getenv('CLIENT_ID')
         self.domain_name = os.getenv('DOMAIN_NAME')
         self.discovery_url = os.getenv('DISCOVERY_URL')

--- a/functions/federated_aws_rp/utils.py
+++ b/functions/federated_aws_rp/utils.py
@@ -12,6 +12,7 @@ import boto3
 from .config import CONFIG
 
 logger = logging.getLogger(__name__)
+logger.setLevel(CONFIG.log_level)
 
 
 class AccessDenied(Exception):

--- a/functions/federated_aws_rp/utils.py
+++ b/functions/federated_aws_rp/utils.py
@@ -320,6 +320,7 @@ def redirect_to_web_console(
         'statusCode': 302,
         'headers': {
             'Content-Type': 'text/html',
+            'Cache-Control': 'max-age=0',
             'Location': url,
             'Set-Cookie': '{}={}; Secure; HttpOnly; Max-Age=3600'.format(
                 CONFIG.cookie_name,


### PR DESCRIPTION
* Create a new CloudFront distribution so that the site will listen for http port 80 requests to redirect them to https (this isn't possible with API Gateway)
* Change the case of the http header names from all lower case to the first letter being uppercase as this changes when going from API Gateway -> Lambda to CloudFront -> API Gateway -> Lambda
* Move deployment from us-west-2 to us-east-1 to accomodate CloudFront
* Add a check in deploy.sh to prevent deploying in any region other than us-east-1
* Change ACM cert for prod to new us-east-1 based cert
* Create new ACM cert for dev (the ACM cer ARN in there before was for an unrelated cert)
* Remove the custom domain name logic from API Gateway as the domain name now will belong to CloudFront and API Gateway will have no custom domain name
* Set http headers to prevent CloudFront from caching

In summary to add http to https redirect to an API Gateway fronted Lambda function you must
* Move the deployment and ACM certs to us-east-1
* Add a CloudFront distribution to the stack
* Modify the Lambda logic to deal with http header names with the first character being uppercase
* Enumerate the HTTP headers you need to have passed through

# Other changes
*  Remove remaining S3 settings and permissions
  * These were leftover after changing from an S3 data store to user cookies in 148a24f
*  Show CloudFormation stack events after a failure during deployment
*  Set loglevel for utils 
