### PR TITLE
Add support for disabling cache on the call for the role list

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -31,7 +31,7 @@ if ! echo "$result" | grep 'arn:aws:sts' >/dev/null; then
   echo "Error : $result"
   exit 1
 elif ! echo "$result" | grep "$ACCOUNT_ID" >/dev/null; then
-  echo "Unable to access AWS or wrong account"
+  echo "Wrong AWS account : $result"
   exit 1
 elif ! python -c 'import boto3; print(boto3.Session().region_name)' | grep "us-east-1" >/dev/null; then
   echo "Region must be us-east-1 to support CloudFront"

--- a/functions/federated_aws_rp/config.py
+++ b/functions/federated_aws_rp/config.py
@@ -10,6 +10,8 @@ class Config:
         self.domain_name = os.getenv('DOMAIN_NAME')
         self.discovery_url = os.getenv('DISCOVERY_URL')
         self.log_level = os.getenv('LOG_LEVEL', 'INFO')
+        self.id_token_for_roles_url = os.getenv('ID_TOKEN_FOR_ROLES_URL',
+            'https://roles-and-aliases.security.mozilla.org/roles')
 
         self.bypass_cache = False
         self.default_session_duration = 43200  # 12 hours
@@ -19,8 +21,7 @@ class Config:
         self.redirect_uri = urllib.parse.urlunparse(
             ('https', self.domain_name, self.redirect_uri_path, '', '', ''))
         self.cookie_name = 'federated-aws-rp'
-        self.id_token_for_roles_url = (
-            'https://roles-and-aliases.security.mozilla.org/roles')
+
         self.default_destionation_url = (
             'https://console.aws.amazon.com/console/home')
         self.role_picker_template = Template('''{% block body %}


### PR DESCRIPTION
* Allow for config override of id_token_for_roles_url
* Clarify deploy wrong account error message

Related PR : mozilla-iam/federated-aws-cli#119