### PR TITLE
Use AWS account alias instead of ID for issuer URL

### DIFF
--- a/functions/federated_aws_rp/app.py
+++ b/functions/federated_aws_rp/app.py
@@ -323,9 +323,11 @@ def lambda_handler(event: dict, context: dict) -> dict:
                         'statusCode': 403,
                         'body': 'Invalid POST data'}
 
-                store['role_arn'] = parsed_body['arn']
-                store['role_account_alias'] = parsed_body['alias']
-                store['role_name'] = parsed_body['role']
+                store.update({
+                    'role_account_alias': parsed_body['alias'],
+                    'role_arn': parsed_body['arn'],
+                    'role_name': parsed_body['role']
+                })
                 return pick_role(store)
             else:
                 return {

--- a/functions/federated_aws_rp/static/index.html
+++ b/functions/federated_aws_rp/static/index.html
@@ -28,7 +28,7 @@
       <strong>{{@key}}</strong>
       <ul>
           {{#each this}}
-              <li><a data-arn="{{arn}}" data-role="{{role}}" href="#{{arn}}" title="{{id}}">{{role}}</a></li>
+              <li><a data-arn="{{arn}}" data-role="{{role}}" data-alias="{{@../key}}" href="#{{arn}}" title="{{id}}">{{role}}</a></li>
           {{/each}}
       </ul>
       {{/each}}

--- a/functions/federated_aws_rp/static/index.js
+++ b/functions/federated_aws_rp/static/index.js
@@ -25,9 +25,9 @@ const selectRole = async (e) => {
     await fetch("/api/roles", {
         method: "POST",
         body: JSON.stringify({
+            alias: e.target.dataset.alias,
             arn: e.target.dataset.arn,
             role: e.target.dataset.role,
-            alias: e.target.dataset.alias
         }),
         headers: {
             "Content-Type": "application/json",

--- a/functions/federated_aws_rp/static/index.js
+++ b/functions/federated_aws_rp/static/index.js
@@ -26,6 +26,8 @@ const selectRole = async (e) => {
         method: "POST",
         body: JSON.stringify({
             arn: e.target.dataset.arn,
+            role: e.target.dataset.role,
+            alias: e.target.dataset.alias
         }),
         headers: {
             "Content-Type": "application/json",

--- a/functions/federated_aws_rp/utils.py
+++ b/functions/federated_aws_rp/utils.py
@@ -355,8 +355,8 @@ def get_aws_federation_url(
         store['role_arn'],
         store['session_duration'])
     issuer_url_query = urllib.parse.urlencode({
-        "account": store['role_arn'].split(':')[4],
-        "role": store['role_arn'].split(':')[5].split('/')[-1]
+        "account": store['role_account_alias'],
+        "role": store['role_name']
     })
     issuer_url = urllib.parse.urlunparse(
         ('https', CONFIG.domain_name, '/', '', issuer_url_query, ''))


### PR DESCRIPTION
This begins passing the AWS account alias to the backend when a role is
picked so that it can be used when constructing the issuer URL. The issuer
URL is the URL the user is shown by AWS after their session has expired.
If the user clicks on the URL it will take them back to federated-aws-rp
to have their session refreshed.

By using the AWS account alias in this URL instead of the AWS account ID
it should be clearer to the user which account it is that they're about
to establish a refreshed session with.

Also see mozilla-iam/mozilla-aws-cli#190