### PR TITLE
Fix bug when AWS account has no alias

### DIFF
--- a/functions/federated_aws_rp/utils.py
+++ b/functions/federated_aws_rp/utils.py
@@ -435,8 +435,8 @@ def get_roles(id_token: str, cache: bool) -> dict:
     roles = {}  # type: dict
     for arn in role_map["roles"]:
         account_id = arn.split(":")[4]
-        alias = role_map.get(
-            "aliases", {}).get(account_id, [account_id])[0]
+        record = role_map.get("aliases", {}).get(account_id)
+        alias = record[0] if record else account_id
         name = arn.split(':')[5].split('/')[-1]
         role = {
             "alias": alias,


### PR DESCRIPTION
If an AWS account has no account alias, this error is thrown
```
[app.py:375] Traceback (most recent call last):
  File "/var/task/federated_aws_rp/app.py", line 313, in lambda_handler
    roles = get_roles(store['id_token'], store.get('cache', True))
  File "/var/task/federated_aws_rp/utils.py", line 438, in get_roles
    alias = role_map.get(
IndexError: list index out of range
```

This is because the idtoken_for_roles endpoint returns an alias map with a record for the account and a value of an empty list.