### PR TITLE
Add account id to account name

### DIFF
--- a/functions/federated_aws_rp/static/index.html
+++ b/functions/federated_aws_rp/static/index.html
@@ -25,7 +25,7 @@
 
     <script id="role-picker-template" type="text-/x-handlebars-template">
       {{#each accounts}}
-      <strong>{{@key}}</strong>
+      <strong>{{@key}}</strong> ({{this.[0].id}})
       <ul>
           {{#each this}}
               <li><a data-arn="{{arn}}" data-role="{{role}}" data-alias="{{@../key}}" href="#{{arn}}" title="{{id}}">{{role}}</a></li>


### PR DESCRIPTION
I am often confused searching the login page for the AWS Account ID that corresponds to the Role I want to select. This simply add the Account ID to the output for faster finding. Open to suggestions or feedback if folks have other workflows that solve this.

Command Line Version of this request:
https://github.com/mozilla-iam/mozilla-aws-cli/pull/241